### PR TITLE
kaminari を使ってページング処理を実装する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 # Ignore bundler config.
 /.bundle
+vendor/bundle
 
 # Ignore the default SQLite database.
 /db/*.sqlite3
@@ -41,3 +42,5 @@ yarn-debug.log*
 .yarn-integrity
 
 /public/uploads/*
+
+.vscode

--- a/Gemfile
+++ b/Gemfile
@@ -59,3 +59,4 @@ end
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 
 gem 'carrierwave'
+gem 'kaminari'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,6 +96,18 @@ GEM
       ruby-vips (>= 2.0.17, < 3)
     jbuilder (2.10.1)
       activesupport (>= 5.0.0)
+    kaminari (1.2.1)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.1)
+      kaminari-activerecord (= 1.2.1)
+      kaminari-core (= 1.2.1)
+    kaminari-actionview (1.2.1)
+      actionview
+      kaminari-core (= 1.2.1)
+    kaminari-activerecord (1.2.1)
+      activerecord
+      kaminari-core (= 1.2.1)
+    kaminari-core (1.2.1)
     listen (3.3.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -249,6 +261,7 @@ DEPENDENCIES
   carrierwave
   i18n_generators
   jbuilder (~> 2.7)
+  kaminari
   listen (~> 3.2)
   puma (~> 4.1)
   rails (~> 6.0.3, >= 6.0.3.4)

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -6,7 +6,7 @@ class BooksController < ApplicationController
   # GET /books
   # GET /books.json
   def index
-    @books = Book.all
+    @books = Book.order(created_at: :desc).order(:id).page(params[:page])
   end
 
   # GET /books/1

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -6,7 +6,7 @@ class BooksController < ApplicationController
   # GET /books
   # GET /books.json
   def index
-    @books = Book.order(created_at: :desc).order(:id).page(params[:page])
+    @books = Book.order(created_at: :desc, id: :asc).page(params[:page])
   end
 
   # GET /books/1

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -30,7 +30,6 @@
 
 <div>
   <%= paginate @books %>
-  <%= page_entries_info @books %>
 </div>
 <br>
 <%= link_to t('views.common.new'), new_book_path %>

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -28,6 +28,9 @@
   </tbody>
 </table>
 
+<div>
+  <%= paginate @books %>
+  <%= page_entries_info @books %>
+</div>
 <br>
-
 <%= link_to t('views.common.new'), new_book_path %>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,26 @@
+<%# The container tag
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+    paginator:     the paginator that renders the pagination tags inside
+-%>
+<%= paginator.render do -%>
+  <nav class="pagination" role="navigation" aria-label="pager">
+    <%= first_page_tag unless current_page.first? %>
+    <%= prev_page_tag unless current_page.first? %>
+    <% each_page do |page| -%>
+      <% if page.display_tag? -%>
+        <%= page_tag page %>
+      <% elsif !page.was_truncated? -%>
+        <%= gap_tag %>
+      <% end -%>
+    <% end -%>
+    <% unless current_page.out_of_range? %>
+      <%= next_page_tag unless current_page.last? %>
+      <%= last_page_tag unless current_page.last? %>
+    <% end %>
+  </nav>
+<% end -%>
+<%= page_entries_info @books %>

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Kaminari.configure do |config|
+  config.default_per_page = 10
+  # config.max_per_page = nil
+  # config.window = 4
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.max_pages = nil
+  # config.params_on_first_page = false
+end

--- a/config/locales/kaminari.ja.yml
+++ b/config/locales/kaminari.ja.yml
@@ -1,0 +1,17 @@
+ja:
+  views:
+    pagination:
+      first: "&laquo; 最初"
+      last: "最後 &raquo;"
+      previous: "&lsaquo; 前"
+      next: "次 &rsaquo;"
+      truncate: "&hellip;"
+  helpers:
+    page_entries_info:
+      one_page:
+        display_entries:
+          zero: "%{entry_name}がありません"
+          one: "1件の%{entry_name}が表示されています"
+          other: "%{count}件の%{entry_name}が表示されています"
+      more_pages:
+        display_entries: "全%{total}件中 %{first}&nbsp;-&nbsp;%{last}件の%{entry_name}が表示されています"

--- a/db/migrate/20201126003950_add_index_book_created_at.rb
+++ b/db/migrate/20201126003950_add_index_book_created_at.rb
@@ -1,0 +1,5 @@
+class AddIndexBookCreatedAt < ActiveRecord::Migration[6.0]
+  def change
+    add_index(:books, :created_at)
+  end
+end

--- a/db/migrate/20201126003950_add_index_book_created_at.rb
+++ b/db/migrate/20201126003950_add_index_book_created_at.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddIndexBookCreatedAt < ActiveRecord::Migration[6.0]
   def change
     add_index(:books, :created_at)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_21_231845) do
+ActiveRecord::Schema.define(version: 2020_11_26_003950) do
 
   create_table "books", force: :cascade do |t|
     t.string "title"
@@ -19,6 +19,7 @@ ActiveRecord::Schema.define(version: 2020_11_21_231845) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "author"
     t.string "picture"
+    t.index ["created_at"], name: "index_books_on_created_at"
   end
 
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -37,7 +37,7 @@ Book.create!(
   Book.create!(
     title: "タイトル #{n}",
     memo: "サンプル #{n}",
-    author: "著者 #{n}",
+    author: "著者 #{n}"
   )
 end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -33,4 +33,12 @@ Book.create!(
   picture: picture_file('erd.jpg')
 )
 
+100.times do |n|
+  Book.create!(
+    title: "タイトル #{n}",
+    memo: "サンプル #{n}",
+    author: "著者 #{n}",
+  )
+end
+
 puts '初期データの投入が完了しました。' # rubocop:disable Rails/Output


### PR DESCRIPTION
## プラクティス概要
Rails アプリに kaminariを使ったページングを実装する。

### 注意点
ページングを付ける場合は、必ず「並び順が一意になるorder」も指定するようにしよう。

## 実装概要
- `kaminari`のインストール
-  `index`ページに各ページへのリンクと案内を表示
-  `@books = Book.order(created_at: :desc).order(:id).page(params[:page])`で並びが一意になるよう修正

### 画面のスクショ
<img width="448" alt="スクリーンショット 2020-11-26 10 18 04" src="https://user-images.githubusercontent.com/50073648/100298028-62f8a780-2fd3-11eb-9266-e2c4f4be5c70.png">

### rubocopの確認
<img width="703" alt="スクリーンショット 2021-01-08 15 30 54" src="https://user-images.githubusercontent.com/50073648/103982498-f1616b00-51c6-11eb-87af-16b62bef42b5.png">
